### PR TITLE
Updated earthengine API to 0.1.226

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 
 CoastSat is an open-source software toolkit written in Python that enables users to obtain time-series of shoreline position at any coastline worldwide from 30+ years (and growing) of publicly available satellite imagery.
 
-To estimate the beach slope from the satellite-derived shorelines and apply a tidal correction check out the [CoastSat.slope](https://github.com/kvos/CoastSat.slope) repository.
-
-Visit the [CoastSat webGIS page](http://coastsat.wrl.unsw.edu.au/) to explore and download a regional-scale dataset of satellite-derived shorelines and beach slopes.
+Visit the [CoastSat website](http://coastsat.wrl.unsw.edu.au/) to explore and download regional-scale datasets of satellite-derived shorelines and beach slopes.
 
 ![Alt text](https://github.com/kvos/CoastSat/blob/development/examples/doc/example.gif)
 
@@ -18,6 +16,8 @@ The underlying approach of the CoastSat toolkit is described in detail in:
 
 Example applications and accuracy of the resulting satellite-derived shorelines are discussed in:
 * Vos K., Harley M.D., Splinter K.D., Simmons J.A., Turner I.L. (2019). Sub-annual to multi-decadal shoreline variability from publicly available satellite imagery. *Coastal Engineering*. 150, 160–174. https://doi.org/10.1016/j.coastaleng.2019.04.004
+
+To estimate the beach slope from the satellite-derived shorelines and apply a tidal correction check out the [CoastSat.slope](https://github.com/kvos/CoastSat.slope) repository.
 
 ### Description
 
@@ -214,4 +214,4 @@ A fork is a copy on which you can make your changes.
 
 2. Vos K., Splinter K.D.,Harley M.D., Simmons J.A., Turner I.L. (2019). CoastSat: a Google Earth Engine-enabled Python toolkit to extract shorelines from publicly available satellite imagery. *Environmental Modelling and Software*. 122, 104528. https://doi.org/10.1016/j.envsoft.2019.104528
 
-3. Training dataset used for pixel classification in CoastSat: https://doi.org/10.5281/zenodo.3334147
+3. Training dataset used for pixel-wise classification in CoastSat: https://doi.org/10.5281/zenodo.3334147

--- a/coastsat/SDS_download.py
+++ b/coastsat/SDS_download.py
@@ -414,7 +414,7 @@ def download_tif(image, polygon, bandsId, filepath):
     """
     
     # for the old version of ee only
-    if ee.__version__ == '0.1.173':
+    if int(ee.__version__[-3:]) <= 201:
         url = ee.data.makeDownloadUrl(ee.data.getDownloadId({
             'image': image.serialize(),
             'region': polygon,
@@ -425,6 +425,7 @@ def download_tif(image, polygon, bandsId, filepath):
         local_zip, headers = urlretrieve(url)
         with zipfile.ZipFile(local_zip) as local_zipfile:
             return local_zipfile.extract('data.tif', filepath)
+    # for the newer versions of ee
     else:
         # crop image on the server and create url to download
         url = ee.data.makeDownloadUrl(ee.data.getDownloadId({

--- a/environment.yml
+++ b/environment.yml
@@ -6,11 +6,11 @@ dependencies:
   - numpy=1.16.3
   - matplotlib=3.0.3
   - pillow=6.2.1
-  - earthengine-api=0.1.224
+  - earthengine-api=0.1.226
   - gdal=2.3.3
   - pandas=0.24.2
   - geopandas=0.4.1
-  - pytz=2019.1
+  - pytz=2020.1
   - scikit-image=0.15.0
   - scikit-learn=0.20.3
   - shapely=1.6.4

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy=1.16.3
   - matplotlib=3.0.3
   - pillow=6.2.1
-  - earthengine-api=0.1.173
+  - earthengine-api=0.1.224
   - gdal=2.3.3
   - pandas=0.24.2
   - geopandas=0.4.1


### PR DESCRIPTION
Some changes to SDS_download.py were necessary to be compatible with the new version of the Earth Engine API (0.1.226). In a recent email the Earth Engine team notified the users that they will not support versions of the API below 0.1.225, see screenshot below:
![image](https://user-images.githubusercontent.com/7217258/86347453-a9a2d980-bca1-11ea-8b68-f7296b649e74.png)

In case you are still using an older version, this version of coastsat should still work as it will check which version you are on and decide how to download the images. To update your version of the EE API, follow the instructions here #100 

I also reordered the functions in SDS_download.py