### PR TITLE
Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.geojson
 *checkpoint.ipynb
 *.csv
+*.xml

--- a/coastsat/SDS_download.py
+++ b/coastsat/SDS_download.py
@@ -282,12 +282,16 @@ def retrieve_images(inputs):
           
     # merge overlapping images (necessary only if the polygon is at the boundary of an image)
     if 'S2' in metadata.keys():
-        try:
-            metadata = merge_overlapping_images(metadata,inputs)
-        except:
-            print('WARNING: there was an error while merging overlapping S2 images,'+
-                  ' please open an issue on Github at https://github.com/kvos/CoastSat/issues'+
-                  ' and include your script so we can find out what happened.')
+        if int(ee.__version__[-3:]) <= 201:
+            try:
+                metadata = merge_overlapping_images(metadata,inputs)
+            except:
+                print('WARNING: there was an error while merging overlapping S2 images,'+
+                      ' please open an issue on Github at https://github.com/kvos/CoastSat/issues'+
+                      ' and include your script so we can find out what happened.')
+        else:
+            print('Overlapping Sentinel-2 images cannot be merged with your version of the earthengine-api (%s)'%ee.__version__)
+            print('To be able to merge overlapping images, revert to version 0.1.201')
 
     # save metadata dict
     with open(os.path.join(im_folder, inputs['sitename'] + '_metadata' + '.pkl'), 'wb') as f:

--- a/example.py
+++ b/example.py
@@ -66,7 +66,7 @@ metadata = SDS_download.get_metadata(inputs)
 settings = { 
     # general parameters:
     'cloud_thresh': 0.5,        # threshold on maximum cloud cover
-    'output_epsg': 28356,       # epsg code of spatial reference system desired for the output   
+    'output_epsg': 3857,        # epsg code of spatial reference system desired for the output   
     # quality control:
     'check_detection': True,    # if True, shows each shoreline detection to the user for validation
     'save_figure': True,        # if True, saves a figure showing the mapped shoreline for each image

--- a/example_jupyter.ipynb
+++ b/example_jupyter.ipynb
@@ -118,7 +118,7 @@
    "source": [
     "## 2. Shoreline extraction\n",
     "\n",
-    "This section maps the position of the shoreline on the satellite images. The user can define the cloud threhold (`cloud_thresh`) and select the spatial reference system in which to output the coordinates of the mapped shorelines (`output_epsg`). See http://spatialreference.org/ to find the EPSG number corresponding to your local coordinate system. Make sure that your are using cartesian coordinates and not spherical coordinates (lat,lon) like WGS84. \n",
+    "This section maps the position of the shoreline on the satellite images. The user can define the cloud threhold (`cloud_thresh`) and select the spatial reference system in which to output the coordinates of the mapped shorelines (`output_epsg`). See http://spatialreference.org/ to find the EPSG number corresponding to your local coordinate system. Make sure that your are using cartesian coordinates and not spherical coordinates (lat,lon) like WGS84. If unsure, use 3857 which is the web mercator projection (used by Google Maps).\n",
     "\n",
     "To quality control each shoreline detection and manually validate the mapped shorelines, the user has the option to set the parameter `check_detection` to **True**. To save a figure for each mapped shoreline set `save_figure` to **True**. \n",
     "\n",
@@ -134,7 +134,7 @@
     "settings = { \n",
     "    # general parameters:\n",
     "    'cloud_thresh': 0.5,        # threshold on maximum cloud cover\n",
-    "    'output_epsg': 28356,       # epsg code of spatial reference system desired for the output   \n",
+    "    'output_epsg': 3857,        # epsg code of spatial reference system desired for the output   \n",
     "    # quality control:\n",
     "    'check_detection': True,    # if True, shows each shoreline detection to the user for validation\n",
     "    'save_figure': True,        # if True, saves a figure showing the mapped shoreline for each image\n",
@@ -387,7 +387,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The function to merge overlapping S2 images was not working properly with the new Earthengine API which crops the images in a different way. Therefore if your Earthengine API package (ee) is higher than 0.1.201, you will not be able to merge overlapping S2 images.

Also change the default projection to 3857 which is the web mercator.