### PR TITLE
Development

### DIFF
--- a/coastsat/SDS_download.py
+++ b/coastsat/SDS_download.py
@@ -767,7 +767,10 @@ def merge_overlapping_images(metadata,inputs):
         # rewrite the .txt file with a new metadata file
         with open(fn_im[0][3], 'w') as f:
             for key in metadict0.keys():
-                f.write('%s\t%s\n'%(key,metadict0[key]))        
+                f.write('%s\t%s\n'%(key,metadict0[key]))  
+                
+        # update filenames list (in case there are triplicates)
+        filenames[pair[0]] = metadict0['filename']
      
     print('%d out of %d Sentinel-2 images were merged (overlapping or duplicate)'%(len(pairs), len(filenames)))
 

--- a/coastsat/SDS_download.py
+++ b/coastsat/SDS_download.py
@@ -278,16 +278,12 @@ def retrieve_images(inputs):
 
     # merge overlapping images (necessary only if the polygon is at the boundary of an image)
     if 'S2' in metadata.keys():
-        if int(ee.__version__[-3:]) <= 201:
-            try:
-                metadata = merge_overlapping_images(metadata,inputs)
-            except:
-                print('WARNING: there was an error while merging overlapping S2 images,'+
-                      ' please open an issue on Github at https://github.com/kvos/CoastSat/issues'+
-                      ' and include your script so we can find out what happened.')
-        else:
-            print('Overlapping Sentinel-2 images cannot be merged with your version of the earthengine-api (%s)'%ee.__version__)
-            print('To be able to merge overlapping images, revert to version 0.1.201')
+        try:
+            metadata = merge_overlapping_images(metadata,inputs)
+        except:
+            print('WARNING: there was an error while merging overlapping S2 images,'+
+                  ' please open an issue on Github at https://github.com/kvos/CoastSat/issues'+
+                  ' and include your script so we can find out what happened.')
 
     # save metadata dict
     with open(os.path.join(im_folder, inputs['sitename'] + '_metadata' + '.pkl'), 'wb') as f:
@@ -697,7 +693,7 @@ def merge_overlapping_images(metadata,inputs):
                     im_binary = np.logical_or(im_std < 1e-6, np.isnan(im_std))
                     mask20 = morphology.dilation(im_binary, morphology.square(3))    
                 # for the newer versions just resample the mask for the 10m bands
-                else: 
+                else:
                     # create mask for the 20m band (SWIR1) by resampling the 10m one
                     mask20 = ndimage.zoom(mask10,zoom=1/2,order=0)
                     mask20 = transform.resize(mask20, im_extra.shape, mode='constant',

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - numpy=1.16.3
   - matplotlib=3.0.3
   - pillow=6.2.1
-  - earthengine-api=0.1.201
+  - earthengine-api=0.1.226
   - gdal=2.3.3
   - pandas=0.24.2
   - geopandas=0.4.1


### PR DESCRIPTION
Fixed some issues with merging overlapping S2 images with newer version of the earthengine-api (ee.__version__ > 0.1.201).
As the cropping algorithm has changed, I had to adapt a few things.
Now it works fine with any version of the earthengine-api and it's capable of merging overlapping S2 images correctly.
Also updated the environment.yml file so that now it installs version 0.1.226 of the earthengine-api (as <0.1.225 are not supported any more).