### PR TITLE
Option to switch off pan-sharpening

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ CoastSat is an open-source software toolkit written in Python that enables users
 :star: **If you like the repo put a star on it!** :star:
 
 ### Latest updates
+:arrow_forward: *(2022/07/20)*
+Option to disable panchromatic sharpening on Landsat 7, 8 and 9 imagery. This setting is recommended for the time being as a bug has been reported with occasional misalignment between the panchromatic and multispectral bands downloaded from Google Earth Engine.
 :arrow_forward: *(2022/05/02)*
 Compatibility with Landsat 9 and Landsat Collection 2
 
@@ -140,12 +142,13 @@ To map the shorelines, the following user-defined settings are needed:
 - `check_detection`: if set to `True` the user can quality control each shoreline detection interactively (recommended when mapping shorelines for the first time) and accept/reject each shoreline.
 - `adjust_detection`: in case users wants more control over the detected shorelines, they can set this parameter to `True`, then they will be able to manually adjust the threshold used to map the shoreline on each image.
 - `save_figure`: if set to `True` a figure of each mapped shoreline is saved under */filepath/sitename/jpg_files/detection*, even if the two previous parameters are set to `False`. Note that this may slow down the process.
+- `pan_off`: set to `True` to disable panchromatic sharpening of Landsat 7, 8, 9 images. Down-sampled images to 15 m are used instead.
 
 There are additional parameters (`min_beach_size`, `buffer_size`, `min_length_sl`, `cloud_mask_issue` and `sand_color`) that can be tuned to optimise the shoreline detection (for Advanced users only). For the moment leave these parameters set to their default values, we will see later how they can be modified.
 
 An example of settings is provided here:
 
-![settings](https://user-images.githubusercontent.com/7217258/95036869-f4a31180-0714-11eb-81fd-9bab011b5b2d.JPG)
+![Capture](https://user-images.githubusercontent.com/7217258/179879844-82f8ebea-0278-490f-9c79-111e5e363160.JPG)
 
 Once all the settings have been defined, the batch shoreline detection can be launched by calling:
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ conda activate coastsat
 conda install -c conda-forge earthengine-api=0.1.236
 conda install gdal geopandas
 conda install scikit-image
-conda install -c anaconda astropy
+conda install -c conda-forge astropy
 conda install spyder notebook
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ CoastSat is an open-source software toolkit written in Python that enables users
 ### Latest updates
 :arrow_forward: *(2022/07/20)*
 Option to disable panchromatic sharpening on Landsat 7, 8 and 9 imagery. This setting is recommended for the time being as a bug has been reported with occasional misalignment between the panchromatic and multispectral bands downloaded from Google Earth Engine.
+
 :arrow_forward: *(2022/05/02)*
 Compatibility with Landsat 9 and Landsat Collection 2
 

--- a/coastsat/SDS_download.py
+++ b/coastsat/SDS_download.py
@@ -20,7 +20,7 @@ from urllib.request import urlretrieve
 import zipfile
 import copy
 import shutil
-import gdal
+from osgeo import gdal
 
 # additional modules
 from datetime import datetime, timedelta

--- a/coastsat/SDS_shoreline.py
+++ b/coastsat/SDS_shoreline.py
@@ -143,7 +143,7 @@ def extract_shorelines(metadata, settings):
             # get image filename
             fn = SDS_tools.get_filenames(filenames[i],filepath, satname)
             # preprocess image (cloud mask + pansharpening/downsampling)
-            im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn, satname, settings['cloud_mask_issue'])
+            im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn, satname, settings['cloud_mask_issue'], settings['pan_off'])
             # get image spatial reference system (epsg code) from metadata dict
             image_epsg = metadata[satname]['epsg'][i]
             

--- a/example.py
+++ b/example.py
@@ -73,7 +73,8 @@ metadata = SDS_download.get_metadata(inputs)
 settings = { 
     # general parameters:
     'cloud_thresh': 0.5,        # threshold on maximum cloud cover
-    'output_epsg': 3857,        # epsg code of spatial reference system desired for the output   
+    'output_epsg': 3857,        # epsg code of spatial reference system desired for the output
+    'pan_off': True,            # True to set pansharpening off
     # quality control:
     'check_detection': True,    # if True, shows each shoreline detection to the user for validation
     'adjust_detection': False,  # if True, allows user to adjust the postion of each shoreline by changing the threhold

--- a/example_jupyter.ipynb
+++ b/example_jupyter.ipynb
@@ -182,7 +182,8 @@
     "settings = { \n",
     "    # general parameters:\n",
     "    'cloud_thresh': 0.5,        # threshold on maximum cloud cover\n",
-    "    'output_epsg': 3857,        # epsg code of spatial reference system desired for the output   \n",
+    "    'output_epsg': 3857,        # epsg code of spatial reference system desired for the output \n",
+    "    'pan_off': False,           # True to set pansharpening off\n",
     "    # quality control:\n",
     "    'check_detection': True,    # if True, shows each shoreline detection to the user for validation\n",
     "    'adjust_detection': False,  # if True, allows user to adjust the postion of each shoreline by changing the threhold\n",
@@ -696,7 +697,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -710,7 +711,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.13"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The current version of CoastSat applies panchromatic sharpening to Landsat 7, 8 and 9 images in order to improve the resolution of the images in the bands that overlap with the 15 m panchromatic band. 
However, recently it was identified by colleagues on the East Coast of the US that for certain polygons the panchromatic band and multispectral bands are misaligned when downloaded from Google Earth Engine. While working on fixing this problem, a temporary solution is to turn off pan-sharpening and only use the multispectral bands. 

This can be done by setting:
`settings['pan_off'] = True`

For the time being, while we work on a solution I recommend to switch pan-sharpening off.
The validation at Narrabeen shows good accuracy without pan-sharpening, although slightly lower (see `validation` branch).

Narrabeen accuracy with pan-sharpening:
![all_transects](https://user-images.githubusercontent.com/7217258/179878564-27af51ab-d475-44c0-805a-73db564aace1.jpg)
Narrabeen accuracy without pan-sharpening:
![all_transects_stats](https://user-images.githubusercontent.com/7217258/179878615-e6f8c7b4-9749-4489-84c9-d3fb9c88761a.jpg)
