### PR TITLE
Save jpgs with imsave parameter quality=100

### DIFF
--- a/coastsat/SDS_preprocess.py
+++ b/coastsat/SDS_preprocess.py
@@ -530,11 +530,11 @@ def create_jpg(im_ms, cloud_mask, date, satname, filepath):
         # location to save image ex. rgb image would be in sitename/RGB/sitename.jpg
         fname=os.path.join(ext_filepath, date + '_'+ext+'_' + satname + '.jpg')
         if ext == "RGB":
-            imsave(fname, im_RGB)
+            imsave(fname, im_RGB, quality=100)
         if ext == "SWIR":
-            imsave(fname, im_SWIR)
+            imsave(fname, im_SWIR, quality=100)
         if ext == "NIR":
-            imsave(fname, im_NIR)
+            imsave(fname, im_NIR, quality=100)
 
 def save_jpg(metadata, settings, **kwargs):
     """


### PR DESCRIPTION
Solves the compression issue mentioned in https://github.com/kvos/CoastSat/pull/340 and https://github.com/kvos/CoastSat/pull/342. jpgs are now saves without any compression by setting the imsave function's argument `quality=100`