### PR TITLE
Update SDS_tools.py re: deprecated gdf.append

### DIFF
--- a/coastsat/SDS_tools.py
+++ b/coastsat/SDS_tools.py
@@ -711,8 +711,7 @@ def output_to_gdf(output, geomtype):
             if counter == 0:
                 gdf_all = gdf
             else:
-                res = pd.concat([gdf_all, gdf])
-                type(res)
+                gdf_all = pd.concat([gdf_all, gdf])
             counter = counter + 1
             
     return gdf_all

--- a/coastsat/SDS_tools.py
+++ b/coastsat/SDS_tools.py
@@ -21,6 +21,7 @@ import pytz
 from datetime import datetime, timedelta
 from scipy import stats, interpolate
 import pyproj
+import pandas as pd
 
 ###################################################################################################
 # COORDINATES CONVERSION FUNCTIONS
@@ -710,7 +711,8 @@ def output_to_gdf(output, geomtype):
             if counter == 0:
                 gdf_all = gdf
             else:
-                gdf_all = gdf_all.append(gdf)
+                res = pd.concat([gdf_all, gdf])
+                type(res)
             counter = counter + 1
             
     return gdf_all


### PR DESCRIPTION
The gdf.append command seems to have deprecated since panda v1.4.0 and results to an AttributeError, which prevents the importation of shorelines into geojson file. To fix this, I updated the line 714 of SDS_tools.py