### PR TITLE
update check_images_available to be able check for images available for entire date range

### DIFF
--- a/coastsat/SDS_download.py
+++ b/coastsat/SDS_download.py
@@ -596,13 +596,22 @@ def check_images_available(inputs):
             # remove from download list the images that are already existing
             if satname in metadata_existing:
                 if len(metadata_existing[satname]['dates']) > 0:
-                    first_date = metadata_existing[satname]['dates'][0] - timedelta(days=1)
-                    last_date = metadata_existing[satname]['dates'][-1] + timedelta(days=1)
-                    date_list = [datetime.fromtimestamp(_['properties']['system:time_start']/1000, tz=pytz.utc) for _ in im_dict_T1[satname]]
-                    idx_new = np.where([np.logical_or(_< first_date, _ > last_date) for _ in date_list])[0]
-                    # only keep images corresponding to dates that are not already existing
-                    im_dict_T1[satname] = [im_dict_T1[satname][_] for _ in idx_new]
-                    print('%s: %d images already exist, %s to download'%(satname, len(date_list)-len(idx_new), len(idx_new)))
+                    # get all the possible availabe dates for the imagery requested
+                    avail_date_list = [datetime.fromtimestamp(image['properties']['system:time_start'] / 1000, tz=pytz.utc).replace( microsecond=0) for image in im_dict_T1[satname]]
+                    # if no images are available, skip this loop
+                    if len(avail_date_list) == 0:
+                        print(f'{satname}:There are {len(avail_date_list)} images available, {len(metadata_existing[satname]["dates"])} images already exist, {len(avail_date_list)} to download')
+                        continue
+                    # get the dates of the images that are already downloaded
+                    downloaded_dates = metadata_existing[satname]['dates']
+                    # if no images are already downloaded, skip this loop and use whats already in im_dict_T1[satname]
+                    if len(downloaded_dates) == 0:
+                        print(f'{satname}:There are {len(avail_date_list)} images available, {len(downloaded_dates)} images already exist, {len(avail_date_list)} to download')
+                        continue
+                    # get the indices of the images that are not already downloaded 
+                    idx_new = np.where([ not avail_date in downloaded_dates for avail_date in avail_date_list])[0]
+                    im_dict_T1[satname] = [im_dict_T1[satname][index] for index in idx_new]
+                    print('%s: %d images already exist, %s to download'%(satname, len(avail_date_list), len(idx_new)))
 
     # if only S2 is in sat_list, stop here as no Tier 2 for Sentinel
     if len(inputs['sat_list']) == 1 and inputs['sat_list'][0] == 'S2':


### PR DESCRIPTION
Hi Killian!

Thanks for building out the functionality to check for existing imagery and continue downloads from the point the download was interrupted. I finally got this feature integrated in coastsat-package and coastseg. 

When I was updating coastsat-package's code to allow for downloads to resume I realized that code in `check_images_available` that checks for existing imagery doesn't actually check if the entire requested date range has been downloaded due to this line 
``` python
idx_new = np.where([np.logical_or(_< first_date, _ > last_date) for _ in date_list])[0]

```
Basically the imagery doesn't always download chronically meaning that it is possible that first date or last date that was downloaded isn't the actual first and last date of the requested date range. If this happens the partial download won't download the missing images for the entire requested date range instead it will only download the missing images for the date range that had already been downloaded for that satellite. You can see that first and last date are derived from the existing imagery in the code below from `check_images_available`:

```
first_date = metadata_existing[satname]['dates'][0] - timedelta(days=1)
last_date = metadata_existing[satname]['dates'][-1] + timedelta(days=1)
```

What this new code does is it gets the entire available date range then gets the existing downloaded dates from the imagery and then it filters out the dates that have already been downloaded. This has been working great for us over at CoastSeg and always gets the entire date range available.

I hope this helps! 

Thanks for maintaining CoastSat for all these years!!