### PR TITLE
remove deprecated matplotlib.cm.get_cmap()

### DIFF
--- a/coastsat/SDS_classify.py
+++ b/coastsat/SDS_classify.py
@@ -9,7 +9,6 @@ Author: Kilian Vos, Water Research Laboratory, University of New South Wales
 import os
 import numpy as np
 import matplotlib.pyplot as plt
-import matplotlib.cm as cm
 from matplotlib.widgets import LassoSelector
 from matplotlib import path
 import pickle
@@ -457,7 +456,7 @@ def format_training_data(features, classes, labels):
     
     return X, y
 
-def plot_confusion_matrix(y_true,y_pred,classes,normalize=False,cmap=plt.cm.Blues):
+def plot_confusion_matrix(y_true,y_pred,classes,normalize=False,cmap=plt.get_cmap("Blues")):
     """
     Function copied from the scikit-learn examples (https://scikit-learn.org/stable/)
     This function plots a confusion matrix.
@@ -547,7 +546,7 @@ def evaluate_classifier(classifier, metadata, settings):
                           constrained_layout=True)
 
     # create colormap for labels
-    cmap = cm.get_cmap('tab20c')
+    cmap = plt.get_cmap('tab20c')
     colorpalette = cmap(np.arange(0,13,1))
     colours = np.zeros((3,4))
     colours[0,:] = colorpalette[5]

--- a/coastsat/SDS_shoreline.py
+++ b/coastsat/SDS_shoreline.py
@@ -27,7 +27,6 @@ from shapely.geometry import LineString
 # other modules
 import matplotlib.patches as mpatches
 import matplotlib.lines as mlines
-import matplotlib.cm as cm
 from matplotlib import gridspec
 import pickle
 from datetime import datetime, timedelta
@@ -768,7 +767,7 @@ def show_detection(im_ms, cloud_mask, im_labels, shoreline,image_epsg, georef,
 
     # compute classified image
     im_class = np.copy(im_RGB)
-    cmap = cm.get_cmap('tab20c')
+    cmap = plt.get_cmap('tab20c')
     colorpalette = cmap(np.arange(0,13,1))
     colours = np.zeros((3,4))
     colours[0,:] = colorpalette[5]
@@ -983,7 +982,7 @@ def adjust_detection(im_ms, cloud_mask, im_nodata, im_labels, im_ref_buffer, ima
 
     # compute classified image
     im_class = np.copy(im_RGB)
-    cmap = cm.get_cmap('tab20c')
+    cmap = plt.get_cmap('tab20c')
     colorpalette = cmap(np.arange(0,13,1))
     colours = np.zeros((3,4))
     colours[0,:] = colorpalette[5]

--- a/example.py
+++ b/example.py
@@ -385,7 +385,7 @@ for key in cross_distance.keys():
 #%% 5.3 Monthly averaging
 
 # compute monthly averages along each transect
-month_colors = plt.cm.get_cmap('tab20')
+month_colors = plt.get_cmap('tab20')
 for key in cross_distance.keys():
     chainage = cross_distance[key]
     # remove nans


### PR DESCRIPTION
In matplotlib version 3.9 and above the `matplotlib.cm.get_cmap()` has been deprecated. This will causes errors with future users of CoastSat. I updated the example scripts as well as `SDS_shoreline.py` and `SDS_classify.py` to update the code to use the new functions to get the colormap.

![image](https://github.com/kvos/CoastSat/assets/61564689/75d13745-433b-410e-a84b-783e5c3c148c)
