### PR TITLE
Fix issues with numpy integration by replacing np.math.atan2 with np.…

### DIFF
--- a/coastsat/SDS_preprocess.py
+++ b/coastsat/SDS_preprocess.py
@@ -939,7 +939,7 @@ def get_reference_sl(metadata, settings):
                     phi = 0
                     deltax = pts_world[k+1,0] - pts_world[k,0]
                     deltay = pts_world[k+1,1] - pts_world[k,1]
-                    phi = np.pi/2 - np.math.atan2(deltax, deltay)
+                    phi = np.pi/2 - np.arctan2(deltax, deltay)                    
                     tf = transform.EuclideanTransform(rotation=phi, translation=pts_world[k,:])
                     pts_world_interp = np.append(pts_world_interp,tf(pt_coords), axis=0)
                 pts_world_interp = np.delete(pts_world_interp,0,axis=0)


### PR DESCRIPTION
### Description

This pull request fixes the issue with numpy integration by replacing `np.math.atan2` with `np.arctan2`.

### Changes Made

- Replaced `np.math.atan2` with `np.arctan2` in `SDS_preprocess.py`.
- Addressed the `DeprecationWarning`: `np.math` is a deprecated alias for the standard library `math` module (Deprecated in Numpy 1.25).

### Related Issue

Closes [#515](https://github.com/kvos/CoastSat/issues/515)
