### PR TITLE
Fix depreciation warning for Landsat Co1 to Co2 migration in two split commits

### DIFF
--- a/classification/train_new_classifier.ipynb
+++ b/classification/train_new_classifier.ipynb
@@ -163,9 +163,9 @@
     "for site in train_sites:\n",
     "    polygon = SDS_tools.polygon_from_kml(os.path.join(filepath_sites,site))\n",
     "    polygon = SDS_tools.smallest_rectangle(polygon)\n",
-    "    sitename = site[:site.find('.')]  \n",
+    "    sitename = site[:site.find('.')]\n",
     "    inputs = {'polygon':polygon, 'dates':dates, 'sat_list':sat_list,\n",
-    "             'sitename':sitename, 'filepath':filepath_images,'landsat_collection': collection}\n",
+    "             'sitename':sitename, 'filepath':filepath_images}\n",
     "    print(sitename)\n",
     "    metadata = SDS_download.retrieve_images(inputs)"
    ]
@@ -291,7 +291,7 @@
     "# or merge all the classes\n",
     "for key in features.keys():\n",
     "    features[key] = np.append(features[key], features_original[key], axis=0)\n",
-    "#features = features_original \n",
+    "#features = features_original\n",
     "for key in features.keys():\n",
     "    print('%s : %d pixels'%(key,len(features[key])))"
    ]
@@ -558,7 +558,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.11.4"
   },
   "toc": {
    "base_numbering": 1,

--- a/coastsat/SDS_classify.py
+++ b/coastsat/SDS_classify.py
@@ -102,7 +102,6 @@ def label_images(metadata,settings):
     """
     
     filepath_train = settings['filepath_train']
-    collection = settings['inputs']['landsat_collection']
 
     # initialize figure
     fig,ax = plt.subplots(1,1,figsize=[17,10], tight_layout=True,sharex=True,
@@ -122,7 +121,6 @@ def label_images(metadata,settings):
             im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn, satname, 
                                                                                                      settings['cloud_mask_issue'],
                                                                                                      settings['pan_off'],
-                                                                                                     collection,
                                                                                                      settings['s2cloudless_prob'])
 
             # compute cloud_cover percentage (with no data pixels)
@@ -534,7 +532,6 @@ def evaluate_classifier(classifier, metadata, settings):
     Saves .jpg images with the output of the classification in the folder ./detection
     
     """  
-    collection = settings['inputs']['landsat_collection']
     # create folder called evaluation
     fp = os.path.join(os.getcwd(), 'evaluation')
     if not os.path.exists(fp):
@@ -574,7 +571,6 @@ def evaluate_classifier(classifier, metadata, settings):
             im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn, satname, 
                                                                                                      settings['cloud_mask_issue'],
                                                                                                      settings['pan_off'],
-                                                                                                     collection,
                                                                                                      settings['s2cloudless_prob'])
             image_epsg = metadata[satname]['epsg'][i]
 

--- a/coastsat/SDS_download.py
+++ b/coastsat/SDS_download.py
@@ -132,14 +132,19 @@ def retrieve_images(inputs):
     im_folder = os.path.join(inputs['filepath'],inputs['sitename'])
     if not os.path.exists(im_folder): os.makedirs(im_folder)
 
+    # Deprecation warning for Collection 1
+    # Landsat Collection 1 is deprecated, and you should migrate to Collection 2.
+    # See this link for details: https://developers.google.com/earth-engine/landsat_c1_to_c2
+
     # bands for each mission
     if inputs['landsat_collection'] == 'C01':
-        qa_band_Landsat = 'BQA'
-    elif inputs['landsat_collection'] == 'C02':
+        raise Exception('Landsat Collection 1 is deprecated. Please migrate to Collection 2. See https://developers.google.com/earth-engine/landsat_c1_to_c2 for more details.')
+        
+    if inputs['landsat_collection'] == 'C02':
         qa_band_Landsat = 'QA_PIXEL'
     else:
         raise Exception('Landsat collection %s does not exist, '%inputs['landsat_collection'] + \
-                        'choose C01 or C02.')
+                        'choose C02.')
     qa_band_S2 = 'QA60'
     # the cloud mask band for Sentinel-2 images is the s2cloudless probability
     bands_dict = {'L5':['B1','B2','B3','B4','B5',qa_band_Landsat],
@@ -557,7 +562,10 @@ def get_metadata(inputs):
 def check_images_available(inputs):
     """
     Scan the GEE collections to see how many images are available for each
-    satellite mission (L5,L7,L8,L9,S2), collection (C01,C02) and tier (T1,T2).
+    satellite mission (L5,L7,L8,L9,S2), collection (C02) and tier (T1,T2).
+    
+    Note: Landsat Collection 1 (C01) is deprecated. Users should migrate to Collection 2 (C02).
+    For more information, visit: https://developers.google.com/earth-engine/landsat_c1_to_c2
 
     KV WRL 2018
 
@@ -584,7 +592,7 @@ def check_images_available(inputs):
 
     # check if EE was initialised or not
     try:
-        ee.ImageCollection('LANDSAT/LT05/C01/T1_TOA')
+        ee.ImageCollection('LANDSAT/LT05/C02/T1_TOA')
     except:
         ee.Initialize()
         
@@ -1272,7 +1280,7 @@ def merge_overlapping_images(metadata,inputs):
         else:
             for index in range(len(pair)):
                 # read image
-                im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn_im[index], sat, False, 'C01')
+                im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn_im[index], sat, False, 'C02')
                 # in Sentinel2 images close to the edge of the image there are some artefacts,
                 # that are squares with constant pixel intensities. They need to be masked in the
                 # raster (GEOTIFF). It can be done using the image standard deviation, which

--- a/coastsat/SDS_preprocess.py
+++ b/coastsat/SDS_preprocess.py
@@ -59,7 +59,7 @@ def preprocess_single(fn, satname, cloud_mask_issue, pan_off, collection, s2clou
     pan_off : boolean
         if True, disable panchromatic sharpening and ignore pan band
     collection: str
-        Landsat collection ,'C01' or 'C02'
+        Landsat collection ,'C02'
     s2cloudless_prob: float [0,100)
         threshold to identify cloud pixels in the s2cloudless probability mask
         
@@ -91,8 +91,7 @@ def preprocess_single(fn, satname, cloud_mask_issue, pan_off, collection, s2clou
     # search for the year the tif was taken with regex and convert to int
     year = int(re.search('[0-9]+',fn_to_split).group(0))
     # after 2022 everything is automatically from Collection 2
-    if collection == 'C01' and year >= 2022:
-        collection = 'C02'
+    collection = 'C02'
         
     #=============================================================================================#
     # L5 images
@@ -360,7 +359,7 @@ def create_cloud_mask(im_QA, satname, cloud_mask_issue, collection):
         True if there is an issue with the cloud mask and sand pixels are being
         erroneously masked on the images
     collection: str
-        Landsat collection ,'C01' or 'C02'
+        Landsat collection 'C02'
         
     Returns:
     -----------
@@ -372,15 +371,7 @@ def create_cloud_mask(im_QA, satname, cloud_mask_issue, collection):
         # 1024 = dense cloud, 2048 = cirrus clouds
         cloud_values = [1024, 2048] 
     else:
-        if collection == 'C01':
-            if  satname in ['L8','L9']:
-                # 2800, 2804, 2808, 2812 = High confidence cloud
-                # 6896, 6900, 6904, 6908 = High confidence cirrus cloud
-                cloud_values = [2800, 2804, 2808, 2812, 6896, 6900, 6904, 6908]
-            elif satname in ['L4','L5','L7','L8']:
-                # 752, 756, 760, 764 = High confidence cloud
-                cloud_values = [752, 756, 760, 764]
-        elif collection == 'C02':
+        if collection == 'C02':
             # function to return flag for n-th bit
             def is_set(x, n):
                 return x & 1 << n != 0   

--- a/coastsat/SDS_shoreline.py
+++ b/coastsat/SDS_shoreline.py
@@ -87,7 +87,6 @@ def extract_shorelines(metadata, settings):
 
     sitename = settings['inputs']['sitename']
     filepath_data = settings['inputs']['filepath']
-    collection = settings['inputs']['landsat_collection']
     filepath_models = os.path.join(os.getcwd(), 'classification', 'models')
     # initialise output structure
     output = dict([])
@@ -152,7 +151,6 @@ def extract_shorelines(metadata, settings):
             im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn, satname, 
                                                                                                      settings['cloud_mask_issue'], 
                                                                                                      settings['pan_off'],
-                                                                                                     collection,
                                                                                                      settings['s2cloudless_prob'])
             # get image spatial reference system (epsg code) from metadata dict
             image_epsg = metadata[satname]['epsg'][i]

--- a/example.py
+++ b/example.py
@@ -42,7 +42,6 @@ dates = ['1984-01-01', '2022-01-01']
 
 # satellite missions
 sat_list = ['L5','L7','L8']
-collection = 'C02' # choose Landsat collection 'C01' or 'C02'
 # name of the site
 sitename = 'NARRA'
 
@@ -56,7 +55,6 @@ inputs = {
     'sat_list': sat_list,
     'sitename': sitename,
     'filepath': filepath_data,
-    'landsat_collection': collection
         }
 
 # before downloading the images, check how many images are available for your inputs


### PR DESCRIPTION
Fix issue #517

Modification for SDS_download.py:

    `retrieve_images` and `check_images_available` functions: Removed references to Collection 1. Added a comment explaining the deprecation warning.
    Updated to use only Collection 2 for Landsat images.

Modification for SDS_preprocess.py:

    `preprocess_single `function: Removed references to Collection 1. Added a comment explaining the deprecation warning.
    Updated to ensure images are processed using Collection 2 only.